### PR TITLE
fix: bugfix http url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the [Localytics](https://www.localytics.com) integratio
 
     ```
     repositories {
-        maven { url 'http://maven.localytics.com/public' }
+        maven { url 'https://maven.localytics.com/public' }
         ...
     }
     ```
@@ -25,8 +25,8 @@ This repository contains the [Localytics](https://www.localytics.com) integratio
 
 ### Documentation
 
-[Localytics integration](http://docs.mparticle.com/?java#localytics)
+[Localytics integration](https://docs.mparticle.com/?java#localytics)
 
 ### License
 
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ buildscript {
     }
 
     repositories {
-        google()
         mavenLocal()
-        jcenter()
+        google()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.mparticle:android-kit-plugin:' + project.version
@@ -21,7 +21,7 @@ android {
     }
 }
 repositories {
-    maven { url 'http://maven.localytics.com/public' }
+    maven { url 'https://maven.localytics.com/public' }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
Updated `http://` urls to `https://` blocking lint in AGP 7.X upgrade

## Testing Plan
Check if any other `http://` references exist to upgrade